### PR TITLE
Update BackgroundMail.java

### DIFF
--- a/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/BackgroundMail.java
+++ b/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/BackgroundMail.java
@@ -312,7 +312,7 @@ public class BackgroundMail {
         private String sendingMessage;
         private String sendingMessageSuccess;
         private String sendingMessageError;
-        private boolean processVisibility;
+        private boolean processVisibility = true;
         private OnSuccessCallback onSuccessCallback;
         private OnFailCallback onFailCallback;
 


### PR DESCRIPTION
Initialized the boolean value for processVisibility to be true in the Builders class since the onPostExecute method will only run if processVisibility variable is true. And i guess that's why the callbacks aren't been invoked
