### PR TITLE
Call Callbacks and Attachment filename

### DIFF
--- a/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/BackgroundMail.java
+++ b/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/BackgroundMail.java
@@ -304,16 +304,21 @@ public class BackgroundMail {
                     if (!TextUtils.isEmpty(sendingMessageSuccess)) {
                         Toast.makeText(mContext, sendingMessageSuccess, Toast.LENGTH_SHORT).show();
                     }
-                    if (onSuccessCallback != null) {
-                        onSuccessCallback.onSuccess();
-                    }
+
                 }else {
                     if (!TextUtils.isEmpty(sendingMessageError)) {
                         Toast.makeText(mContext, sendingMessageError, Toast.LENGTH_SHORT).show();
                     }
-                    if (onFailCallback != null) {
-                        onFailCallback.onFail();
-                    }
+
+                }
+            }
+            if (result) {
+                if (onSuccessCallback != null) {
+                    onSuccessCallback.onSuccess();
+                }
+            } else {
+                if (onFailCallback != null) {
+                    onFailCallback.onFail();
                 }
             }
         }

--- a/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/util/GmailSender.java
+++ b/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/util/GmailSender.java
@@ -80,7 +80,7 @@ public class GmailSender extends javax.mail.Authenticator {
         BodyPart messageBodyPart = new MimeBodyPart();
         DataSource source = new FileDataSource(filename);
         messageBodyPart.setDataHandler(new DataHandler(source));
-        messageBodyPart.setFileName(filename);
+        messageBodyPart.setFileName(source.getName());
 
         _multipart.addBodyPart(messageBodyPart);
     }


### PR DESCRIPTION
There are two commits:

1. The callbacks should be called regardless of the `processVisibility` flag in the `postExecute` method.
2. The attachment filename should be name of the file attached and not it's entire path.