### PR TITLE
Add feature to ignore use default session from java mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GmailBackground
-a small library to send a email in background withou user interaction 
+A small library to send a email in background without user interaction 
 ```java
         BackgroundMail.newBuilder(this)
                 .withUsername("username@gmail.com")
@@ -21,6 +21,10 @@ a small library to send a email in background withou user interaction
                     }
                 })
                 .send();
+```
+If you have the feature for user to change sender `username` and `password`. You should ignore use default session. See more detail [here](http://docs.oracle.com/javaee/6/api/javax/mail/Session.html#getDefaultInstance)
+```java
+.withUseDefaultSession(false)
 ```
 **Gradle via jitpack**
 

--- a/app/src/main/java/com/creativityapps/gmailbackground/MainActivity.java
+++ b/app/src/main/java/com/creativityapps/gmailbackground/MainActivity.java
@@ -57,6 +57,7 @@ public class MainActivity extends AppCompatActivity {
                 .withMailto("toemail@gmail.com")
                 .withSubject("this is the subject")
                 .withBody("this is the body")
+                .withUseDefaultSession(false)
                 .withOnSuccessCallback(new BackgroundMail.OnSuccessCallback() {
                     @Override
                     public void onSuccess() {

--- a/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/BackgroundMail.java
+++ b/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/BackgroundMail.java
@@ -21,13 +21,14 @@ import java.util.List;
 
 
 public class BackgroundMail {
-    String TAG = "BackgroundMail";
+    private final String TAG = BackgroundMail.class.getSimpleName();
     private String username;
     private String password;
     private String mailto;
     private String subject;
     private String body;
     private String type;
+    private boolean useDefaultSession;
     private String sendingMessage;
     private String sendingMessageSuccess;
     private String sendingMessageError;
@@ -68,6 +69,7 @@ public class BackgroundMail {
         subject = builder.subject;
         body = builder.body;
         type = builder.type;
+        useDefaultSession = builder.useDefaultSession;
         setSendingMessage(builder.sendingMessage);
         setSendingMessageSuccess(builder.sendingMessageSuccess);
         setSendingMessageError(builder.sendingMessageError);
@@ -121,6 +123,14 @@ public class BackgroundMail {
     @NonNull
     public String getType() {
         return type;
+    }
+
+    public void setUseDefaultSession(boolean useDefaultSession) {
+        this.useDefaultSession = useDefaultSession;
+    }
+
+    public boolean isUseDefaultSession() {
+        return useDefaultSession;
     }
 
     public void showVisibleProgress(boolean state) {
@@ -279,7 +289,7 @@ public class BackgroundMail {
         @Override
         protected Boolean doInBackground(String... arg0) {
             try {
-                GmailSender sender = new GmailSender(username, password);
+                GmailSender sender = new GmailSender(username, password, useDefaultSession);
                 if (!attachments.isEmpty()) {
                     for (int i = 0; i < attachments.size(); i++) {
                         if (!attachments.get(i).isEmpty()) {
@@ -327,6 +337,7 @@ public class BackgroundMail {
         private String subject;
         private String body;
         private String type = BackgroundMail.TYPE_PLAIN;
+        private boolean useDefaultSession = true;
         private ArrayList<String> attachments = new ArrayList<>();
         private String sendingMessage;
         private String sendingMessageSuccess;
@@ -385,6 +396,11 @@ public class BackgroundMail {
         //set email mime type
         public Builder withType(@NonNull String type) {
             this.type = type;
+            return this;
+        }
+
+        public Builder withUseDefaultSession(boolean useDefaultSession) {
+            this.useDefaultSession = useDefaultSession;
             return this;
         }
 

--- a/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/util/GmailSender.java
+++ b/gmailbackgroundlibrary/src/main/java/com/creativityapps/gmailbackgroundlibrary/util/GmailSender.java
@@ -32,7 +32,7 @@ public class GmailSender extends javax.mail.Authenticator {
         Security.addProvider(new JSSEProvider());
     }
 
-    public GmailSender(String user, String password) {
+    public GmailSender(String user, String password, boolean useDefaultSession) {
         this.user = user;
         this.password = password;
 
@@ -46,7 +46,7 @@ public class GmailSender extends javax.mail.Authenticator {
         props.put("mail.smtp.socketFactory.fallback", "false");
         props.setProperty("mail.smtp.quitwait", "false");
 
-        session = Session.getDefaultInstance(props, this);
+        session = useDefaultSession ? Session.getDefaultInstance(props, this) : Session.getInstance(props, this);
         _multipart = new MimeMultipart();
     }
 


### PR DESCRIPTION
- We should NOT always use `getDefaultInstance` due to some reason has explained [here](http://docs.oracle.com/javaee/6/api/javax/mail/Session.html#getDefaultInstance).
- Add feature to ignore use default session from java mail via `withUseDefaultSession(false)`